### PR TITLE
Improve search bar

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7080,6 +7080,11 @@
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
+    "sleep-promise": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
+      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -67,6 +67,7 @@
     "react-visibility-sensor": "^5.1.1",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "sleep-promise": "^8.0.1"
   }
 }

--- a/web/src/collection/components/Fingerprints/FPGridList/FPGridList.js
+++ b/web/src/collection/components/Fingerprints/FPGridList/FPGridList.js
@@ -5,6 +5,7 @@ import { makeStyles } from "@material-ui/styles";
 import Grid from "@material-ui/core/Grid";
 import { composition } from "./composition";
 import FpGridListItem from "../FPGridListItem";
+import FpGridListLoadTrigger from "../FPGridListLoadTrigger";
 
 function items(breakpoint, dense) {
   const decrease = dense ? 1 : 0;
@@ -57,5 +58,8 @@ FpGridList.propTypes = {
 
 // Access item type from container type.
 FpGridList.Item = FpGridListItem;
+
+// Access loading trigger from container type
+FpGridList.LoadTrigger = FpGridListLoadTrigger;
 
 export default FpGridList;

--- a/web/src/collection/components/Fingerprints/FPGridListItem/FPGridListItem.js
+++ b/web/src/collection/components/Fingerprints/FPGridListItem/FPGridListItem.js
@@ -3,13 +3,10 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
 import { FingerprintType } from "../type";
-import Paper from "@material-ui/core/Paper";
 import MediaPreview from "../../../../common/components/MediaPreview";
 import VideocamOutlinedIcon from "@material-ui/icons/VideocamOutlined";
 import MoreHorizOutlinedIcon from "@material-ui/icons/MoreHorizOutlined";
 import IconButton from "@material-ui/core/IconButton";
-import Grid from "@material-ui/core/Grid";
-import { composition } from "../FPGridList";
 import AttributeText from "../../../../common/components/AttributeText";
 import { useIntl } from "react-intl";
 import {
@@ -21,15 +18,9 @@ import EventAvailableOutlinedIcon from "@material-ui/icons/EventAvailableOutline
 import ExifIcon from "../../../../common/components/icons/ExifIcon";
 import VolumeOffOutlinedIcon from "@material-ui/icons/VolumeOffOutlined";
 import Marked from "../../../../common/components/Marked";
+import FpGridListItemContainer from "./FPGridListItemContainer";
 
 const useStyles = makeStyles((theme) => ({
-  itemContainer: {},
-  gridItem: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "space-around",
-    boxShadow: "0 12px 18px 0 rgba(0,0,0,0.08)",
-  },
   asButton: {
     cursor: "pointer",
   },
@@ -108,95 +99,81 @@ const FpGridListItem = React.memo(function FpGridListItem(props) {
 
   const intl = useIntl();
   const messages = useMessages(intl);
-  const decrease = dense ? 1 : 0;
   const handleClick = useCallback(() => onClick(file), [file, onClick]);
 
   const classes = useStyles();
   return (
-    <Grid
-      item
-      xs={12 / Math.max(composition.xs - decrease, 1)}
-      sm={12 / Math.max(composition.sm - decrease, 1)}
-      md={12 / Math.max(composition.md - decrease, 1)}
-      lg={12 / Math.max(composition.lg - decrease, 1)}
-      xl={12 / Math.max(composition.xl - decrease, 1)}
-      className={classes.itemContainer}
+    <FpGridListItemContainer
+      className={clsx(button && classes.asButton, className)}
+      dense={dense}
+      onClick={handleClick}
     >
-      <Paper
-        className={clsx(
-          classes.gridItem,
-          button && classes.asButton,
-          className
-        )}
-        onClick={handleClick}
-      >
-        <MediaPreview
-          src={file.preview}
-          alt="preview"
-          className={classes.preview}
+      <MediaPreview
+        src={file.preview}
+        alt="preview"
+        className={classes.preview}
+      />
+      <div className={classes.nameContainer}>
+        <div className={classes.iconContainer}>
+          <VideocamOutlinedIcon className={classes.icon} />
+        </div>
+        <div className={classes.name}>
+          <Marked mark={highlight}>{file.filename}</Marked>
+        </div>
+        <IconButton size="small">
+          <MoreHorizOutlinedIcon fontSize="small" />
+        </IconButton>
+      </div>
+      <div className={classes.attrRow}>
+        <AttributeText
+          name={messages.attr.fingerprint}
+          value={file.fingerprint}
+          variant="primary"
+          size="small"
         />
-        <div className={classes.nameContainer}>
-          <div className={classes.iconContainer}>
-            <VideocamOutlinedIcon className={classes.icon} />
-          </div>
-          <div className={classes.name}>
-            <Marked mark={highlight}>{file.filename}</Marked>
-          </div>
-          <IconButton size="small">
-            <MoreHorizOutlinedIcon fontSize="small" />
-          </IconButton>
+        <div className={classes.dividerContainer}>
+          <div className={classes.divider} />
         </div>
-        <div className={classes.attrRow}>
-          <AttributeText
-            name={messages.attr.fingerprint}
-            value={file.fingerprint}
-            variant="primary"
-            size="small"
-          />
-          <div className={classes.dividerContainer}>
-            <div className={classes.divider} />
-          </div>
-          <AttributeText
-            name={messages.attr.quality}
-            value={file.metadata.quality}
-            defaultValue="Unknown"
-            variant="primary"
-            size="small"
-          />
-          <div className={classes.dividerContainer}>
-            <div className={classes.divider} />
-          </div>
-          <AttributeText
-            name={messages.attr.duration}
-            value={formatDuration(file.metadata.length, intl)}
-            variant="primary"
-            size="small"
-          />
+        <AttributeText
+          name={messages.attr.quality}
+          value={file.metadata.quality}
+          defaultValue="Unknown"
+          variant="primary"
+          size="small"
+        />
+        <div className={classes.dividerContainer}>
+          <div className={classes.divider} />
         </div>
-        <div className={classes.attrRow}>
-          <AttributeText
-            value={formatDate(file.metadata.uploadDate, intl)}
-            icon={EventAvailableOutlinedIcon}
-            variant="normal"
-            defaultValue="Unknown"
-            size="small"
-          />
-          <div className={classes.dividerContainer}>
-            <div className={classes.divider} />
-          </div>
-          <AttributeText
-            value={formatBool(file.metadata.hasEXIF, intl)}
-            icon={ExifIcon}
-            variant="primary"
-            size="small"
-          />
-          <div className={classes.dividerContainer}>
-            <div className={classes.divider} />
-          </div>
-          <VolumeOffOutlinedIcon className={classes.volume} />
+        <AttributeText
+          name={messages.attr.duration}
+          value={formatDuration(file.metadata.length, intl)}
+          variant="primary"
+          size="small"
+        />
+      </div>
+      <div className={classes.attrRow}>
+        <AttributeText
+          value={formatDate(file.metadata.uploadDate, intl)}
+          icon={EventAvailableOutlinedIcon}
+          variant="normal"
+          defaultValue="Unknown"
+          size="small"
+        />
+        <div className={classes.dividerContainer}>
+          <div className={classes.divider} />
         </div>
-      </Paper>
-    </Grid>
+        <AttributeText
+          value={formatBool(file.metadata.hasEXIF, intl)}
+          icon={ExifIcon}
+          variant="primary"
+          size="small"
+        />
+        <div className={classes.dividerContainer}>
+          <div className={classes.divider} />
+        </div>
+        <VolumeOffOutlinedIcon className={classes.volume} />
+      </div>
+    </FpGridListItemContainer>
   );
 });
 

--- a/web/src/collection/components/Fingerprints/FPGridListItem/FPGridListItemContainer.js
+++ b/web/src/collection/components/Fingerprints/FPGridListItem/FPGridListItemContainer.js
@@ -1,0 +1,48 @@
+import React from "react";
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/styles";
+import Paper from "@material-ui/core/Paper";
+import Grid from "@material-ui/core/Grid";
+import { composition } from "../FPGridList";
+
+const useStyles = makeStyles({
+  itemContainer: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-around",
+    boxShadow: "0 12px 18px 0 rgba(0,0,0,0.08)",
+  },
+});
+
+function FpGridListItemContainer(props) {
+  const { children, dense = false, className, ...other } = props;
+  const decrease = dense ? 1 : 0;
+  const classes = useStyles();
+
+  return (
+    <Grid
+      item
+      xs={12 / Math.max(composition.xs - decrease, 1)}
+      sm={12 / Math.max(composition.sm - decrease, 1)}
+      md={12 / Math.max(composition.md - decrease, 1)}
+      lg={12 / Math.max(composition.lg - decrease, 1)}
+      xl={12 / Math.max(composition.xl - decrease, 1)}
+    >
+      <Paper className={clsx(classes.itemContainer, className)} {...other}>
+        {children}
+      </Paper>
+    </Grid>
+  );
+}
+
+FpGridListItemContainer.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  dense: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default FpGridListItemContainer;

--- a/web/src/collection/components/Fingerprints/FPGridListItem/index.js
+++ b/web/src/collection/components/Fingerprints/FPGridListItem/index.js
@@ -1,1 +1,2 @@
 export { default } from "./FPGridListItem";
+export { default as FPGridListItemContainer } from "./FPGridListItemContainer";

--- a/web/src/collection/components/Fingerprints/FPGridListLoadTrigger/FPGridListLoadTrigger.js
+++ b/web/src/collection/components/Fingerprints/FPGridListLoadTrigger/FPGridListLoadTrigger.js
@@ -1,0 +1,112 @@
+import React, { useCallback } from "react";
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/styles";
+import { useIntl } from "react-intl";
+import { FPGridListItemContainer } from "../FPGridListItem";
+import VisibilitySensor from "react-visibility-sensor";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+const useStyles = makeStyles((theme) => ({
+  trigger: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing(3),
+    minHeight: 140,
+  },
+  triggerArea: {
+    minWidth: 1,
+    minHeight: 1,
+  },
+  errorMessage: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "column",
+    ...theme.mixins.title4,
+  },
+  retryLink: {
+    color: theme.palette.primary.main,
+    cursor: "pointer",
+    paddingTop: theme.spacing(1),
+  },
+}));
+
+/**
+ * Get i18n text.
+ */
+function useMessages() {
+  const intl = useIntl();
+  return {
+    retry: intl.formatMessage({ id: "actions.retry" }),
+    error: intl.formatMessage({ id: "file.load.error" }),
+  };
+}
+
+function FpGridListLoadTrigger(props) {
+  const { loading, error, onLoad, hasMore, dense = false, className } = props;
+  const classes = useStyles();
+  const messages = useMessages();
+
+  const handleVisibilityChange = useCallback(
+    (visible) => {
+      if (visible && !loading && hasMore) {
+        onLoad();
+      }
+    },
+    [onLoad, loading, hasMore]
+  );
+
+  if (!hasMore) {
+    return null;
+  }
+
+  return (
+    <FPGridListItemContainer
+      className={clsx(classes.trigger, className)}
+      dense={dense}
+    >
+      {!loading && !error && (
+        <VisibilitySensor onChange={handleVisibilityChange} partialVisibility>
+          <div className={classes.triggerArea} />
+        </VisibilitySensor>
+      )}
+      {loading && <CircularProgress size={30} color="primary" />}
+      {!loading && error && (
+        <div className={classes.errorMessage}>
+          {messages.error}
+          <div className={classes.retryLink} onClick={onLoad}>
+            {messages.retry}
+          </div>
+        </div>
+      )}
+    </FPGridListItemContainer>
+  );
+}
+
+FpGridListLoadTrigger.propTypes = {
+  /**
+   * Indicate dense packing of file list items
+   */
+  dense: PropTypes.bool,
+  /**
+   * Indicate loading error
+   */
+  error: PropTypes.bool,
+  /**
+   * File loading is in progress
+   */
+  loading: PropTypes.bool.isRequired,
+  /**
+   * Trigger loading of the next portion of files
+   */
+  onLoad: PropTypes.func.isRequired,
+  /**
+   * Whether more files could be loaded
+   */
+  hasMore: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+};
+
+export default FpGridListLoadTrigger;

--- a/web/src/collection/components/Fingerprints/FPGridListLoadTrigger/index.js
+++ b/web/src/collection/components/Fingerprints/FPGridListLoadTrigger/index.js
@@ -1,0 +1,1 @@
+export { default } from "./FPGridListLoadTrigger";

--- a/web/src/collection/components/Fingerprints/FPLinearList.js
+++ b/web/src/collection/components/Fingerprints/FPLinearList.js
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
 import FpLinearListItem from "./FPLinearListItem";
+import FPLinearListLoadTrigger from "./FPLinearListLoadTrigger";
 
 const useStyles = makeStyles(() => ({
   list: {
@@ -28,5 +29,8 @@ FpLinearList.propTypes = {
 
 // Access item type from the container type
 FpLinearList.Item = FpLinearListItem;
+
+// Access load trigger from the container type
+FpLinearList.LoadTrigger = FPLinearListLoadTrigger;
 
 export default FpLinearList;

--- a/web/src/collection/components/Fingerprints/FPLinearListItem.js
+++ b/web/src/collection/components/Fingerprints/FPLinearListItem.js
@@ -22,9 +22,6 @@ const useStyles = makeStyles((theme) => ({
   decor: {
     marginBottom: theme.spacing(2),
     backgroundColor: theme.palette.background.paper,
-    "&:hover": {
-      borderColor: theme.palette.primary.light,
-    },
     borderRadius: 4,
     borderStyle: "solid",
     borderWidth: 1,
@@ -37,6 +34,9 @@ const useStyles = makeStyles((theme) => ({
   },
   buttonStyle: {
     cursor: "pointer",
+    "&:hover": {
+      borderColor: theme.palette.primary.light,
+    },
   },
   icon: {
     color: theme.palette.primary.contrastText,

--- a/web/src/collection/components/Fingerprints/FPLinearListLoadTrigger.js
+++ b/web/src/collection/components/Fingerprints/FPLinearListLoadTrigger.js
@@ -1,0 +1,108 @@
+import React, { useCallback } from "react";
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/styles";
+import VisibilitySensor from "react-visibility-sensor";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { useIntl } from "react-intl";
+
+const useStyles = makeStyles((theme) => ({
+  trigger: {
+    marginBottom: theme.spacing(2),
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: 4,
+    borderStyle: "solid",
+    borderWidth: 1,
+    borderColor: theme.palette.border.light,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing(3),
+    minHeight: theme.spacing(2 * 3 + 5),
+  },
+  triggerArea: {
+    minWidth: 1,
+    minHeight: 1,
+  },
+  errorMessage: {
+    display: "flex",
+    alignItems: "center",
+    ...theme.mixins.title4,
+  },
+  retryLink: {
+    color: theme.palette.primary.main,
+    cursor: "pointer",
+    paddingLeft: theme.spacing(1),
+  },
+}));
+
+/**
+ * Get i18n text.
+ */
+function useMessages() {
+  const intl = useIntl();
+  return {
+    retry: intl.formatMessage({ id: "actions.retry" }),
+    error: intl.formatMessage({ id: "file.load.error" }),
+  };
+}
+
+function FPLinearListLoadTrigger(props) {
+  const { loading, error, onLoad, hasMore, className } = props;
+  const classes = useStyles();
+  const messages = useMessages();
+
+  const handleVisibilityChange = useCallback(
+    (visible) => {
+      if (visible && !loading && hasMore) {
+        onLoad();
+      }
+    },
+    [onLoad, loading, hasMore]
+  );
+
+  if (!hasMore) {
+    return null;
+  }
+
+  return (
+    <div className={clsx(classes.trigger, className)}>
+      {!loading && !error && (
+        <VisibilitySensor onChange={handleVisibilityChange} partialVisibility>
+          <div className={classes.triggerArea} />
+        </VisibilitySensor>
+      )}
+      {loading && <CircularProgress size={30} color="primary" />}
+      {!loading && error && (
+        <div className={classes.errorMessage}>
+          {messages.error}
+          <div className={classes.retryLink} onClick={onLoad}>
+            {messages.retry}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+FPLinearListLoadTrigger.propTypes = {
+  /**
+   * Indicate loading error
+   */
+  error: PropTypes.bool,
+  /**
+   * File loading is in progress
+   */
+  loading: PropTypes.bool.isRequired,
+  /**
+   * Trigger loading of the next portion of files
+   */
+  onLoad: PropTypes.func.isRequired,
+  /**
+   * Whether more files could be loaded
+   */
+  hasMore: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+};
+
+export default FPLinearListLoadTrigger;

--- a/web/src/collection/components/Fingerprints/FingerprintsView.js
+++ b/web/src/collection/components/Fingerprints/FingerprintsView.js
@@ -11,6 +11,7 @@ import FpLinearList from "./FPLinearList";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectCounts,
+  selectError,
   selectFiles,
   selectFilters,
   selectLoading,
@@ -122,8 +123,9 @@ function FingerprintsView(props) {
   const classes = useStyles();
   const [showFilters, setShowFilters] = useState(false);
   const [sort, setSort] = useState("");
-  const [view, setView] = useState(View.grid);
+  const [view, setView] = useState(View.list);
   const [category, setCategory] = useState(Category.total);
+  const error = useSelector(selectError);
   const loading = useSelector(selectLoading);
   const files = useSelector(selectFiles);
   const filters = useSelector(selectFilters);
@@ -211,11 +213,11 @@ function FingerprintsView(props) {
                 onClick={handleClickVideo}
               />
             ))}
-            <LoadTrigger
+            <List.LoadTrigger
+              error={error}
               loading={loading}
               onLoad={handleFetchPage}
-              hasMore={files.length < counts.total}
-              showProgress
+              hasMore={error || files.length < counts.total}
             />
           </List>
           <div className={classes.fab}>

--- a/web/src/collection/components/Fingerprints/FingerprintsView.js
+++ b/web/src/collection/components/Fingerprints/FingerprintsView.js
@@ -123,7 +123,7 @@ function FingerprintsView(props) {
   const classes = useStyles();
   const [showFilters, setShowFilters] = useState(false);
   const [sort, setSort] = useState("");
-  const [view, setView] = useState(View.list);
+  const [view, setView] = useState(View.grid);
   const [category, setCategory] = useState(Category.total);
   const error = useSelector(selectError);
   const loading = useSelector(selectLoading);
@@ -217,6 +217,7 @@ function FingerprintsView(props) {
               error={error}
               loading={loading}
               onLoad={handleFetchPage}
+              dense={showFilters}
               hasMore={error || files.length < counts.total}
             />
           </List>

--- a/web/src/collection/components/Fingerprints/SearchTextInput.js
+++ b/web/src/collection/components/Fingerprints/SearchTextInput.js
@@ -10,6 +10,7 @@ import { useIntl } from "react-intl";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import IconButton from "@material-ui/core/IconButton";
 import SearchOutlinedIcon from "@material-ui/icons/SearchOutlined";
+import ClearOutlinedIcon from "@material-ui/icons/ClearOutlined";
 
 const useStyles = makeStyles(() => ({
   input: {
@@ -33,6 +34,7 @@ function SearchTextInput(props) {
   const [timeoutHandle, setTimeoutHandle] = useState(null);
 
   const handleChange = useCallback((event) => setQuery(event.target.value), []);
+  const handleClear = useCallback(() => setQuery(""), []);
 
   const handleSearch = useCallback(() => {
     clearTimeout(timeoutHandle);
@@ -69,13 +71,16 @@ function SearchTextInput(props) {
         onChange={handleChange}
         endAdornment={
           <InputAdornment position="end">
-            <IconButton
-              aria-label="search fingerprints"
-              onClick={handleSearch}
-              edge="end"
-            >
-              <SearchOutlinedIcon />
-            </IconButton>
+            {!query && <SearchOutlinedIcon />}
+            {query && (
+              <IconButton
+                aria-label="search fingerprints"
+                onClick={handleClear}
+                edge="end"
+              >
+                <ClearOutlinedIcon />
+              </IconButton>
+            )}
           </InputAdornment>
         }
         labelWidth={145}

--- a/web/src/collection/components/Fingerprints/SearchTextInput.js
+++ b/web/src/collection/components/Fingerprints/SearchTextInput.js
@@ -43,6 +43,17 @@ function SearchTextInput(props) {
     }
   }, [query, onSearch, timeoutHandle]);
 
+  const handleControlKeys = useCallback(
+    (event) => {
+      if (event.key === "Enter") {
+        handleSearch();
+      } else if (event.key === "Escape") {
+        handleClear();
+      }
+    },
+    [handleSearch]
+  );
+
   useEffect(() => {
     clearTimeout(timeoutHandle);
     const newHandle = setTimeout(handleSearch, 1000);
@@ -84,6 +95,7 @@ function SearchTextInput(props) {
           </InputAdornment>
         }
         labelWidth={145}
+        onKeyDown={handleControlKeys}
       />
     </FormControl>
   );

--- a/web/src/collection/state/reducers.js
+++ b/web/src/collection/state/reducers.js
@@ -8,6 +8,7 @@ import {
 } from "./actions";
 
 export const initialState = {
+  error: false,
   loading: false,
   files: [],
   filters: {
@@ -51,12 +52,14 @@ export function collRootReducer(state = initialState, action) {
         ...state,
         files: [...action.files],
         counts: { ...action.counts },
+        error: false,
         loading: false,
       };
     case ACTION_UPDATE_FILTERS_FAILURE:
       return {
         ...state,
         files: [],
+        error: true,
         loading: false,
       };
     case ACTION_FETCH_FILES:
@@ -67,6 +70,7 @@ export function collRootReducer(state = initialState, action) {
     case ACTION_FETCH_FILES_SUCCESS:
       return {
         ...state,
+        error: false,
         files: extendFiles(state.files, action.files),
         counts: { ...action.counts },
         page: state.page + 1,
@@ -75,6 +79,7 @@ export function collRootReducer(state = initialState, action) {
     case ACTION_FETCH_FILES_FAILURE:
       return {
         ...state,
+        error: true,
         loading: false,
       };
     default:

--- a/web/src/collection/state/selectors.js
+++ b/web/src/collection/state/selectors.js
@@ -10,3 +10,5 @@ export const selectFilters = (state) => selectColl(state).filters;
 export const selectCounts = (state) => selectColl(state).counts;
 
 export const selectLoading = (state) => selectColl(state).loading;
+
+export const selectError = (state) => selectColl(state).error;

--- a/web/src/i18n/locales/default.en-US.json
+++ b/web/src/i18n/locales/default.en-US.json
@@ -30,6 +30,7 @@
     "actions.useGridView": "Grid View",
     "actions.searchFingerprints": "Search Fingerprints",
     "actions.compare": "Compare",
+    "actions.retry": "Retry",
     "sort.duration": "Duration",
     "sort.size": "Size",
     "sort.date": "Date",
@@ -103,6 +104,7 @@
     "file.title": "Video",
     "file.tabInfo": "Video Information",
     "file.tabObjects": "Objects",
-    "file.tabExif": "EXIF Data"
+    "file.tabExif": "EXIF Data",
+    "file.load.error": "Error loading files."
   }
 }


### PR DESCRIPTION
Implements additional improvements for #80: 
* Change search icon into clear-button when search-bar is not empty
* Force search (ignore delay) on `Enter` key press
* Clear search on `Escape` key press
* Handle fetch errors in file list and grid views. 

Concerning fetch error handling. Previously on fetching error grid/list view kept trying to retrieve file-metadata from the server. Now a mock item will be displayed with error message and `Retry` link (see screen shots below)

Grid: 
![error_grid](https://user-images.githubusercontent.com/38860530/91293848-d87d8d80-e7c2-11ea-8698-025364cd1bb0.png)

List: 
![error_list](https://user-images.githubusercontent.com/38860530/91293858-dca9ab00-e7c2-11ea-8c17-2062be3fe6b3.png)