### PR TITLE
Fix go back navigation

### DIFF
--- a/web/src/collection/components/FileBrowserPage/CategorySelector/CategorySelector.js
+++ b/web/src/collection/components/FileBrowserPage/CategorySelector/CategorySelector.js
@@ -11,40 +11,36 @@ import AdjustOutlinedIcon from "@material-ui/icons/AdjustOutlined";
 import { formatCount } from "../../../../common/helpers/format";
 import Grid from "@material-ui/core/Grid";
 
-function useNames() {
-  const intl = useIntl();
-  return {
-    [MatchCategory.all]: intl.formatMessage({ id: "search.category.all" }),
-    [MatchCategory.duplicates]: intl.formatMessage({
-      id: "search.category.duplicates",
-    }),
-    [MatchCategory.related]: intl.formatMessage({
-      id: "search.category.related",
-    }),
-    [MatchCategory.unique]: intl.formatMessage({
-      id: "search.category.unique",
-    }),
-  };
-}
-
-const categories = [
-  MatchCategory.all,
-  MatchCategory.duplicates,
-  MatchCategory.related,
-  MatchCategory.unique,
+/**
+ * Selectable categories.
+ */
+const options = [
+  {
+    category: MatchCategory.all,
+    title: "search.category.all",
+    icon: AllInclusiveOutlinedIcon,
+  },
+  {
+    category: MatchCategory.duplicates,
+    title: "search.category.duplicates",
+    icon: FileCopyOutlinedIcon,
+  },
+  {
+    category: MatchCategory.related,
+    title: "search.category.related",
+    icon: GroupWorkOutlinedIcon,
+  },
+  {
+    category: MatchCategory.unique,
+    title: "search.category.unique",
+    icon: AdjustOutlinedIcon,
+  },
 ];
-
-const icons = {
-  [MatchCategory.all]: AllInclusiveOutlinedIcon,
-  [MatchCategory.duplicates]: FileCopyOutlinedIcon,
-  [MatchCategory.related]: GroupWorkOutlinedIcon,
-  [MatchCategory.unique]: AdjustOutlinedIcon,
-};
 
 function CategorySelector(props) {
   const { category: selected, onChange, counts, dense, className } = props;
-  const names = useNames();
   const intl = useIntl();
+  const format = (id) => intl.formatMessage({ id });
 
   return (
     <Grid
@@ -52,16 +48,16 @@ function CategorySelector(props) {
       spacing={2}
       className={clsx(className)}
       role="listbox"
-      aria-label={intl.formatMessage({ id: "aria.label.categorySelector" })}
+      aria-label={format("aria.label.categorySelector")}
     >
-      {categories.map((category) => (
+      {options.map((option) => (
         <CategoryButton
-          name={names[category]}
-          icon={icons[category]}
-          quantity={formatCount(counts[category])}
-          onClick={() => onChange(category)}
-          selected={category === selected}
-          key={category}
+          name={format(option.title)}
+          icon={option.icon}
+          quantity={formatCount(counts[option.category])}
+          onClick={() => onChange(option.category)}
+          selected={option.category === selected}
+          key={option.category}
           dense={dense}
         />
       ))}

--- a/web/src/collection/components/FileBrowserPage/FileBrowserPage.js
+++ b/web/src/collection/components/FileBrowserPage/FileBrowserPage.js
@@ -22,9 +22,10 @@ import Fab from "@material-ui/core/Fab";
 import Zoom from "@material-ui/core/Zoom";
 import VisibilitySensor from "react-visibility-sensor";
 import { scrollIntoView } from "../../../common/helpers/scroll";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { routes } from "../../../routing/routes";
 import { useIntl } from "react-intl";
+import { defaultFilters } from "../../state/reducers";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -137,16 +138,22 @@ function FileBrowserPage(props) {
   const List = listComponent(view);
   const intl = useIntl();
   const showFiltersRef = useRef();
+  const location = useLocation();
+  const keepFilters = location.state?.keepFilters;
+
+  console.log("LOCATION", location);
 
   useEffect(() => {
-    dispatch(updateFilters({ query: "" }));
-  }, []);
+    if (!keepFilters) {
+      dispatch(updateFilters(defaultFilters));
+    }
+  }, [keepFilters]);
 
   const handleFetchPage = useCallback(() => dispatch(fetchFiles()), []);
 
   const handleToggleFilters = useCallback(() => {
     setShowFilters(!showFilters);
-    setTimeout(() => showFiltersRef.current.focus());
+    setTimeout(() => showFiltersRef.current?.focus());
   }, [showFilters, showFiltersRef]);
 
   const handleQuery = useCallback((query) => {

--- a/web/src/collection/components/FileBrowserPage/FileBrowserPage.js
+++ b/web/src/collection/components/FileBrowserPage/FileBrowserPage.js
@@ -17,7 +17,7 @@ import {
   selectFilters,
   selectLoading,
 } from "../../state/selectors";
-import { fetchFiles, updateFilters } from "../../state";
+import { fetchFiles, selectColl, updateFilters } from "../../state";
 import Fab from "@material-ui/core/Fab";
 import Zoom from "@material-ui/core/Zoom";
 import VisibilitySensor from "react-visibility-sensor";
@@ -126,6 +126,7 @@ function FileBrowserPage(props) {
   const classes = useStyles();
   const [showFilters, setShowFilters] = useState(false);
   const [view, setView] = useState(View.grid);
+  const collState = useSelector(selectColl);
   const error = useSelector(selectError);
   const loading = useSelector(selectLoading);
   const files = useSelector(selectFiles);
@@ -141,13 +142,11 @@ function FileBrowserPage(props) {
   const location = useLocation();
   const keepFilters = location.state?.keepFilters;
 
-  console.log("LOCATION", location);
-
   useEffect(() => {
-    if (!keepFilters) {
+    if (!keepFilters || collState.neverLoaded) {
       dispatch(updateFilters(defaultFilters));
     }
-  }, [keepFilters]);
+  }, [keepFilters, collState.neverLoaded]);
 
   const handleFetchPage = useCallback(() => dispatch(fetchFiles()), []);
 

--- a/web/src/collection/components/FileSummaryHeader/FileSummaryHeader.js
+++ b/web/src/collection/components/FileSummaryHeader/FileSummaryHeader.js
@@ -53,9 +53,10 @@ function FileSummaryHeader(props) {
   const small = useSmallScreen();
   const messages = getMessages(intl);
 
-  const handleBack = useCallback(() => history.push(routes.collection.home), [
-    history,
-  ]);
+  const handleBack = useCallback(
+    () => history.push(routes.collection.fingerprints, { keepFilters: true }),
+    [history]
+  );
 
   return (
     <Paper className={clsx(classes.header, className)}>

--- a/web/src/collection/components/FileSummaryHeader/FileSummaryHeader.js
+++ b/web/src/collection/components/FileSummaryHeader/FileSummaryHeader.js
@@ -11,6 +11,7 @@ import { useHistory } from "react-router";
 import FileSummary from "../FileSummary";
 import useTheme from "@material-ui/styles/useTheme";
 import { useMediaQuery } from "@material-ui/core";
+import { routes } from "../../../routing/routes";
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -52,16 +53,15 @@ function FileSummaryHeader(props) {
   const small = useSmallScreen();
   const messages = getMessages(intl);
 
-  const back = history.length > 0;
-  const handleBack = useCallback(() => history.goBack(), [history]);
+  const handleBack = useCallback(() => history.push(routes.collection.home), [
+    history,
+  ]);
 
   return (
     <Paper className={clsx(classes.header, className)}>
-      {back && (
-        <IconButton onClick={handleBack} aria-label={messages.goBack}>
-          <ArrowBackOutlinedIcon />
-        </IconButton>
-      )}
+      <IconButton onClick={handleBack} aria-label={messages.goBack}>
+        <ArrowBackOutlinedIcon />
+      </IconButton>
       <FileSummary file={file} divider className={classes.summary}>
         <FileSummary.Name />
         <FileSummary.Fingerprint />

--- a/web/src/collection/components/VideoDetailsPage/ObjectTimeLine/ObjectTimeLine.js
+++ b/web/src/collection/components/VideoDetailsPage/ObjectTimeLine/ObjectTimeLine.js
@@ -31,9 +31,9 @@ function ObjectTimeLine(props) {
       className={clsx(classes.timeline, className)}
       aria-label={intl.formatMessage({ id: "aria.label.objectTimeline" })}
     >
-      {groups.map((group) => (
+      {groups.map((group, index) => (
         <ObjectGroup
-          key={group[0].position}
+          key={index}
           fullLength={file.metadata.length}
           objects={group}
           onJump={onJump}

--- a/web/src/collection/components/VideoDetailsPage/seekTo.js
+++ b/web/src/collection/components/VideoDetailsPage/seekTo.js
@@ -2,7 +2,8 @@
  * Create callback to seek to the given position in video file
  */
 export function seekTo(player, file) {
-  // always add 1 millisecond to workaround ReactPlayer's NPE bug
+  // Always add 1 millisecond to position to workaround ReactPlayer's NPE bug.
+  // Always add 1 millisecond to file length to handle zero file length.
   return (object) =>
-    player.seekTo((object.position + 1) / file.metadata.length);
+    player.seekTo((object.position + 1) / (file.metadata.length + 1));
 }

--- a/web/src/collection/state/reducers.js
+++ b/web/src/collection/state/reducers.js
@@ -32,7 +32,7 @@ export const initialState = {
   },
   limit: 20,
   counts: {
-    total: 0,
+    all: 0,
     related: 0,
     duplicates: 0,
     unique: 0,

--- a/web/src/collection/state/reducers.js
+++ b/web/src/collection/state/reducers.js
@@ -17,6 +17,7 @@ import { MatchCategory } from "./MatchCategory";
 import { FileSort } from "./FileSort";
 
 export const initialState = {
+  neverLoaded: true,
   error: false,
   loading: false,
   files: [],
@@ -173,6 +174,7 @@ export function collRootReducer(state = initialState, action) {
         filters: { ...state.filters, ...action.filters },
         files: [],
         loading: true,
+        neverLoaded: false,
       };
     case ACTION_UPDATE_FILTERS_SUCCESS:
       return {
@@ -193,6 +195,7 @@ export function collRootReducer(state = initialState, action) {
       return {
         ...state,
         loading: true,
+        neverLoaded: false,
       };
     case ACTION_FETCH_FILES_SUCCESS:
       return {

--- a/web/src/collection/state/reducers.js
+++ b/web/src/collection/state/reducers.js
@@ -64,6 +64,11 @@ export const initialState = {
   },
 };
 
+/**
+ * Default collection filters.
+ */
+export const defaultFilters = initialState.filters;
+
 function ids(entities) {
   const result = new Set();
   for (let entity of entities) {

--- a/web/src/server-api/Server/Transform.js
+++ b/web/src/server-api/Server/Transform.js
@@ -64,7 +64,7 @@ export default class Transform {
       stdAverage: data.meta.video_avg_std,
       maxDiff: data.meta.video_max_dif,
       flagged: data.meta.flagged,
-      length: data.meta.video_length * 1000 || data.exif?.General_Duration,
+      length: data.meta.video_length * 1000 || data.exif?.General_Duration || 0,
     };
   }
 


### PR DESCRIPTION
Resolves #172 

Also contains the following improvements: 
1. Handle missing file length on video details page. 
2. Fix bug in match category selector.
3. Preserve loaded files and filters when navigate from video details page back to the file list page. 