### PR TITLE
Fix docker cache cleanup

### DIFF
--- a/.github/workflows/ci-dedup.yml
+++ b/.github/workflows/ci-dedup.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Clean Docker Cache
         if: github.event_name == 'push'
         run: |
-          docker rm $(docker ps -a -q)
           docker image prune
       - name: Build and Push CPU Image
         if: github.event_name == 'push'
@@ -62,7 +61,6 @@ jobs:
       - name: Clean Docker Cache
         if: github.event_name == 'push'
         run: |
-          docker rm $(docker ps -a -q)
           docker image prune -a
       - name: Build and Push GPU Image
         if: github.event_name == 'push'


### PR DESCRIPTION
It seems like in GitHub actions environment there are some
background containers that shouldn't be stopped/removed. Thus we
should remove only unused layers from the Docker cache.